### PR TITLE
Improve `show` command output to include rpath information

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 exclude: (^auditwheel_emscripten/emscripten_tools/)
 default_language_version:
-  python: "3.12"
+  python: "3.13"
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: "v5.0.0"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Changed
+
+- The output format of `pyodide auditwheel show` has been simplified to be more `ldd`-like. It also shows the location of the dependencies in the wheel
+  using the runtime path of the shared libraries.
+
+- `pyodide auditwheel show` now accepts `-r`, `--with-runtime-paths` option to show the runtime paths of the shared libraries in the wheel.
+
+- `auditwheel.show()` function now returns the runtime paths of the shared libraries in the wheel as well.
+
 ## [0.1.0] - 2025-04-04
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -39,26 +39,29 @@ Python-in-the-browser using Emscripten.
 ```
 
 ```sh
-# wget https://cdn.jsdelivr.net/pyodide/v0.21.3/full/Shapely-1.8.2-cp310-cp310-emscripten_3_1_14_wasm32.whl
-$ pyodide auditwheel show Shapely-1.8.2-cp310-cp310-emscripten_3_1_14_wasm32.whl
+$ pyodide auditwheel show shapely-2.0.7-cp313-cp313-pyodide_2025_0_wasm32.whl
+shapely/speedups/_speedups.cpython-310-wasm32-emscripten.so:
+        libgeos_c.so
 
-The following external shared libraries are required:
-{
-│   'shapely/speedups/_speedups.cpython-310-wasm32-emscripten.so': ['libgeos_c.so'],
-│   'shapely/vectorized/_vectorized.cpython-310-wasm32-emscripten.so': ['libgeos_c.so']
-}
+shapely/vectorized/_vectorized.cpython-310-wasm32-emscripten.so:
+        libgeos_c.so
 ```
 
 ```sh
-$ pyodide auditwheel repair --libdir <directory which contains libgeos_c.so> Shapely-1.8.2-cp310-cp310-emscripten_3_1_14_wasm32.whl
+$ pyodide auditwheel repair --libdir <directory which contains libgeos_c.so> shapely-2.0.7-cp313-cp313-pyodide_2025_0_wasm32.whl
+shapely/lib.cpython-313-wasm32-emscripten.so:
+        libgeos_c.so => shapely.libs/libgeos_c.so
 
-Repaired wheel has following external shared libraries:
-{
-│   'Shapely.libs/libgeos.so.3.10.3': [],
-│   'Shapely.libs/libgeos_c.so': ['libgeos.so.3.10.3'],
-│   'shapely/speedups/_speedups.cpython-310-wasm32-emscripten.so': ['libgeos_c.so'],
-│   'shapely/vectorized/_vectorized.cpython-310-wasm32-emscripten.so': ['libgeos_c.so']
-}
+shapely/_geometry_helpers.cpython-313-wasm32-emscripten.so:
+        libgeos_c.so => shapely.libs/libgeos_c.so
+
+shapely/_geos.cpython-313-wasm32-emscripten.so:
+        libgeos_c.so => shapely.libs/libgeos_c.so
+
+shapely.libs/libgeos.so:
+
+shapely.libs/libgeos_c.so:
+        libgeos.so => shapely.libs/libgeos.so
 ```
 
 

--- a/auditwheel_emscripten/cli/main.py
+++ b/auditwheel_emscripten/cli/main.py
@@ -1,9 +1,9 @@
 from pathlib import Path
 
 import typer
-from rich.pretty import pprint
 
 from .. import function_type, get_exports, get_imports, repair, show
+from ..show import locate_dependency
 from ..wheel_utils import unpack_if_wheel
 
 app = typer.Typer()
@@ -14,18 +14,55 @@ def main():
     """Auditwheel-like tool for emscripten wheels and shared libraries."""
 
 
+def print_dylib(
+    library: str,
+    deps: list[str],
+    runtime_paths: list[str],
+    libraries: list[str],
+    show_runtime_paths: bool = False,
+):
+    """
+    Print shared library dependencies and runtime paths.
+    The output looks similar to the output of `ldd`
+    """
+    print(f"{library}:")
+
+    for dep in deps:
+        line = f"\t{dep:>10}"
+        deppath = locate_dependency(library, dep, libraries, runtime_paths)
+        if deppath:
+            line += f" => {deppath}"
+        print(line)
+
+    if show_runtime_paths and runtime_paths:
+        print("\n\tRuntime search paths:")
+        for path in runtime_paths:
+            print(f"\t  {path}")
+
+    print()
+
+
 @app.command("show")
 def _show(
     wheel_or_so_file: Path = typer.Argument(
         ..., help="Path to wheel or a shared library file."
-    )
+    ),
+    show_runtime_paths: bool = typer.Option(
+        False,
+        "-r",
+        "--with-runtime-paths",
+        help="Show runtime paths.",
+    ),
 ):
     """
     Show shared library dependencies of a wheel or a shared library file.
     """
     try:
-        dependencies = show(wheel_or_so_file)
-        pprint(dependencies)
+        libraries = show(wheel_or_so_file)
+        for lib, (deps, runtime_paths) in libraries.items():
+            print_dylib(
+                lib, deps, runtime_paths, list(libraries.keys()), show_runtime_paths
+            )
     except Exception as e:
         raise e
 
@@ -41,6 +78,12 @@ def _repair(
         None,
         help="Directory to output repaired wheel or shared library. (default: overwrite the input file)",
     ),
+    show_runtime_paths: bool = typer.Option(
+        False,
+        "-r",
+        "--with-runtime-paths",
+        help="Show runtime paths.",
+    ),
 ):
     """
     Repair a wheel file: copy shared libraries to the wheel directory.
@@ -52,8 +95,11 @@ def _repair(
             output_dir,
             modify_rpath=True,
         )
-        dependencies = show(repaired_wheel)
-        pprint(dependencies)
+        libraries = show(repaired_wheel)
+        for lib, (deps, runtime_paths) in libraries.items():
+            print_dylib(
+                lib, deps, runtime_paths, list(libraries.keys()), show_runtime_paths
+            )
     except RuntimeError as e:
         raise e
 

--- a/auditwheel_emscripten/repair.py
+++ b/auditwheel_emscripten/repair.py
@@ -21,7 +21,7 @@ def resolve_sharedlib(wheel_file: str | Path, libdir: str | Path) -> dict[str, P
 
     dependencies_resolved: dict[str, Path] = {}
     while dep_queue:
-        lib, deps = dep_queue.popleft()
+        lib, (deps, _) = dep_queue.popleft()
         for dep in deps:
             if dep in dependencies_resolved:
                 continue

--- a/auditwheel_emscripten/show.py
+++ b/auditwheel_emscripten/show.py
@@ -1,5 +1,6 @@
 import tempfile
 from pathlib import Path
+import os.path
 
 from .lib_utils import get_all_shared_libs_in_dir, sharedlib_regex
 from .module import parse_dylink_section
@@ -7,26 +8,31 @@ from .wheel_utils import is_emscripten_wheel, unpack
 from .wasm_utils import is_wasm_module
 
 
-def show_dylib(dylib_file: Path) -> list[str]:
+def show_dylib(dylib_file: Path) -> tuple[list[str], list[str]]:
     if not is_wasm_module(dylib_file):
         raise RuntimeError(f"{dylib_file} is not a WASM file")
 
     dylink = parse_dylink_section(dylib_file)
-    return dylink.needed
+    return dylink.needed, dylink.runtime_paths
 
 
-def show_wheel_unpacked(wheel_extract_dir: str | Path) -> dict[str, list[str]]:
+def show_wheel_unpacked(
+    wheel_extract_dir: str | Path,
+) -> dict[str, tuple[list[str], list[str]]]:
     dependencies = {}
 
     shared_libs = get_all_shared_libs_in_dir(wheel_extract_dir)
     for shared_lib in shared_libs:
-        deps = show_dylib(shared_lib)
-        dependencies[shared_lib.relative_to(wheel_extract_dir).as_posix()] = deps
+        deps, runtime_paths = show_dylib(shared_lib)
+        dependencies[shared_lib.relative_to(wheel_extract_dir).as_posix()] = (
+            deps,
+            runtime_paths,
+        )
 
     return dependencies
 
 
-def show_wheel(wheel_file: Path) -> dict[str, list[str]]:
+def show_wheel(wheel_file: Path) -> dict[str, tuple[list[str], list[str]]]:
     if not is_emscripten_wheel(wheel_file.name):
         raise RuntimeError(f"{wheel_file} is not an emscripten wheel")
 
@@ -37,7 +43,7 @@ def show_wheel(wheel_file: Path) -> dict[str, list[str]]:
         return show_wheel_unpacked(extract_dir)
 
 
-def show(wheel_or_so_file: str | Path) -> dict[str, list[str]]:
+def show(wheel_or_so_file: str | Path) -> dict[str, tuple[list[str], list[str]]]:
     file = Path(wheel_or_so_file)
     if not file.exists():
         raise RuntimeError(f"no such file: {file}")
@@ -53,3 +59,21 @@ def show(wheel_or_so_file: str | Path) -> dict[str, list[str]]:
         }
     else:
         raise RuntimeError(f"unknown file type: {file}")
+
+
+def locate_dependency(
+    base: str, dep: str, libraries: list[str], runtime_paths: list[str]
+) -> str | None:
+    """
+    Check if the dependencies exists in the wheel using runtime paths.
+    If the dependency exists, return the path to the dependency.
+    Otherwise, return None.
+    """
+    for path in runtime_paths:
+        relpath = path.replace("$ORIGIN", "..")
+        # Always use unix-style separators
+        candidate = os.path.normpath(str(Path(base) / relpath / dep)).replace("\\", "/")
+        if candidate in libraries:
+            return candidate
+
+    return None

--- a/test/test_repair.py
+++ b/test/test_repair.py
@@ -71,7 +71,7 @@ def test_repair(tmp_path, wheel_file, expected):
     repaired_wheel = repair(wheel_file, TEST_DATA, tmp_path, modify_rpath=True)
 
     libs = show(repaired_wheel)
-    libs_dependencies = list(chain(*libs.values()))
+    libs_dependencies = list(chain(*[dep for (dep, _) in libs.values()]))
     for expected_lib in expected:
         assert (
             expected_lib in libs_dependencies

--- a/test/test_show.py
+++ b/test/test_show.py
@@ -3,7 +3,7 @@ from itertools import chain
 import pytest
 from paths import GALPY_WHEEL, NUMPY_WHEEL, SHAPELY_WHEEL
 
-from auditwheel_emscripten.show import show
+from auditwheel_emscripten.show import show, locate_dependency
 
 
 @pytest.mark.parametrize(
@@ -59,8 +59,46 @@ def test_show(wheel_file, expected):
 def test_show_dependencies(wheel_file, expected):
     libs = show(wheel_file)
 
-    libs_dependencies = list(chain(*libs.values()))
+    libs_dependencies = list(chain(*[dep for (dep, _) in libs.values()]))
     for expected_lib in expected:
         assert (
             expected_lib in libs_dependencies
         ), f"expected lib {expected_lib} not found in dependencies"
+
+
+def test_locate_dependency():
+    # Test case 1: Dependency found in runtime path
+    base = "dir/lib.so"
+    dep = "libdep.so"
+    libraries = ["dir/subdir/libdep.so", "other/lib.so"]
+    runtime_paths = ["$ORIGIN/subdir"]
+
+    result = locate_dependency(base, dep, libraries, runtime_paths)
+    assert result == "dir/subdir/libdep.so"
+
+    # Test case 2: Dependency not found
+    base = "dir/lib.so"
+    dep = "libmissing.so"
+    libraries = ["dir/subdir/libdep.so", "other/lib.so"]
+    runtime_paths = ["$ORIGIN/subdir"]
+
+    result = locate_dependency(base, dep, libraries, runtime_paths)
+    assert result is None
+
+    # Test case 3: Multiple runtime paths, dependency in second path
+    base = "dir/lib.so"
+    dep = "libdep.so"
+    libraries = ["dir/path2/libdep.so", "other/lib.so"]
+    runtime_paths = ["$ORIGIN/path1", "$ORIGIN/path2"]
+
+    result = locate_dependency(base, dep, libraries, runtime_paths)
+    assert result == "dir/path2/libdep.so"
+
+    # Test case 4: rpath contains ".."
+    base = "dir/subdir/lib.so"
+    dep = "libdep.so"
+    libraries = ["dir/libdep.so", "other/lib.so"]
+    runtime_paths = ["$ORIGIN/.."]
+
+    result = locate_dependency(base, dep, libraries, runtime_paths)
+    assert result == "dir/libdep.so"


### PR DESCRIPTION
This PR changes the output of `pyodide auditwheel show`.

Previously, it just pretty-printed the output of {libname: dependencies}, while now it shows a `ldd`-like output. It also shows the resolved path of each dependencies similar to ldd.

There is no breaking change, and most of the changes are for my own personal use to make debugging related to rpaths easier.

